### PR TITLE
Modifying the 'username_header' Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,18 @@ and visit the generated tokenized link (looks like:  http://127.0.0.1:8888/?toke
 
 ## Run!
 
-Once you are ready, build and launch the application with
+Once you are ready, build and launch the application from the ```jupyterhub_service``` account:
+
+1. First to switch from root to ```jupyterhub_service``` account:
+```
+  machinectl shell --uid=jupyterhub_service
+```
+
+2. Then to build and launch the application:
 
 ```
-docker-compose build
-docker-compose up -d
+  docker-compose build
+  docker-compose up -d
 ```
 
 Read the [Docker Compose manual](https://docs.docker.com/compose/) to

--- a/jupyterhub/jupyterhub_config.py
+++ b/jupyterhub/jupyterhub_config.py
@@ -13,6 +13,7 @@ c.JupyterHub.hub_ip = os.environ['HUB_IP']
 # These settings are specific to the CRC's proprietary authentication package `crc_jupyter_auth`
 c.JupyterHub.authenticator_class = 'crc_jupyter_auth.RemoteUserAuthenticator'
 c.Authenticator.required_vpn_role = 'SAM-SSLVPNSAMUsers'
+c.JupyterHub.username_header = 'cn'
 c.Authenticator.missing_user_redirect = 'https://crc.pitt.edu/Access-CRC-Web-Portals'
 c.Authenticator.missing_role_redirect = 'https://crc.pitt.edu/Access-CRC-Web-Portals'
 c.Authenticator.admin_users = {'djp81', 'yak73', 'leb140'}
@@ -21,7 +22,7 @@ c.Authenticator.admin_users = {'djp81', 'yak73', 'leb140'}
 c.Spawner.default_url = '/lab'
 c.Spawner.debug = True
 c.Spawner.cpu_limit = 1
-c.Spawner.mem_limit = '4G'
+c.Spawner.mem_limit = '1G'
 
 # Docker spawner
 # Common convention is to mount user home directories under /home/jovyan/work
@@ -30,13 +31,6 @@ c.DockerSpawner.image = os.environ['DOCKER_JUPYTER_CONTAINER']
 c.DockerSpawner.notebook_dir = '/home/jovyan/work'
 c.DockerSpawner.volumes = {'jupyterhub-user-{username}': '/home/jovyan/work'}
 c.DockerSpawner.network_name = os.environ['DOCKER_NETWORK_NAME']
-
-#c.ProfilesSpawner.profiles = [
-#    ("Host Process", 'local', 'jupyterhub.spawner.LocalProcessSpawner', {'ip': '0.0.0.0'}),
-#    #("Host Process", 'local', 'jupyterhub.spawner.LocalProcessSpawner', {'ip': '0.0.0.0'}),
-#    # ("Teach Cluster - 1 gpu - 2 cpus, 3 hours", 'teach2c1g3h', 'batchspawner.SlurmSpawner',
-#    # dict(req_runtime='3:00:00', req_cluster='teach', req_partition='gpu', req_options='-c 2 --mem=24G --gres=gpu:1', req_srun='')),
-#]
 
 ## Services
 c.JupyterHub.load_roles = [


### PR DESCRIPTION
- Modifying the 'username_header' parameter in jupyterhub_config.py to align with the SSO service parameter (cn instead of Cn).
- Using 1G as memory limit for DockerSpawner to give space for more spawned sessions.
- Modifying the ReadME file of the repo to add the note that building and launching the application is performed from the jupyterhub_service account.
